### PR TITLE
Updated netstandard and Nuget for Opc-UA-Client

### DIFF
--- a/Prediktor.UA.Client/Prediktor.UA.Client.csproj
+++ b/Prediktor.UA.Client/Prediktor.UA.Client.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
 	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.372.56" />
+	  <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.54" />
 	  <PackageReference Include="Prediktor.Log" Version="1.0.8" />
 	  <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
 		<PrivateAssets>all</PrivateAssets>

--- a/Prediktor.UA.Console/Prediktor.UA.Console.csproj
+++ b/Prediktor.UA.Console/Prediktor.UA.Console.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua">
-      <Version>1.4.372.56</Version>
+      <Version>1.5.374.54</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated from netstandard2.0 to netstandard2.1 
and 
OPCFoundation.NetStandard.Opc.Ua from version 1.4.372.56 to 1.5.374.54