### PR TITLE
Update Nuget for OPCFoundation.NetStandard.Opc.Ua and GitVersion.MsBuild

### DIFF
--- a/CertGenCore/CertGenCore.csproj
+++ b/CertGenCore/CertGenCore.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
+		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/CertGenCore/CertGenCore.csproj
+++ b/CertGenCore/CertGenCore.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+		<PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/OPC-UA-Client.sln
+++ b/OPC-UA-Client.sln
@@ -9,6 +9,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prediktor.UA.Console", "Pre
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CertGenCore", "CertGenCore\CertGenCore.csproj", "{5990E6FE-2692-42B5-A28A-244F64064F80}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8B395197-04F7-4808-AAD2-1D8CA941B667}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		azure-pipeline-opcuaclient.yml = azure-pipeline-opcuaclient.yml
+		gitversion.yml = gitversion.yml
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Prediktor.UA.Client/Prediktor.UA.Client.csproj
+++ b/Prediktor.UA.Client/Prediktor.UA.Client.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-  </PropertyGroup>
-	
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+ 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+	</PropertyGroup>
+
 	<ItemGroup>
-	  <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.78" />
-	  <PackageReference Include="Prediktor.Log" Version="1.0.8" />
-	  <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
-		<PrivateAssets>all</PrivateAssets>
-		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
+		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.78" />
+		<PackageReference Include="Prediktor.Log" Version="1.0.8" />
+		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="uaconfig_example.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="uaconfig_example.xml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Prediktor.UA.Client/Prediktor.UA.Client.csproj
+++ b/Prediktor.UA.Client/Prediktor.UA.Client.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.54" />
+	  <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.78" />
 	  <PackageReference Include="Prediktor.Log" Version="1.0.8" />
-	  <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+	  <PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/Prediktor.UA.Console/Prediktor.UA.Console.csproj
+++ b/Prediktor.UA.Console/Prediktor.UA.Console.csproj
@@ -44,7 +44,7 @@
       <Project>{954aa52b-1c98-4bc4-9b65-3b6a557f3597}</Project>
       <Name>Prediktor.UA.Client</Name>
     </ProjectReference>
-	<PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
+	<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>

--- a/Prediktor.UA.Console/Prediktor.UA.Console.csproj
+++ b/Prediktor.UA.Console/Prediktor.UA.Console.csproj
@@ -44,14 +44,14 @@
       <Project>{954aa52b-1c98-4bc4-9b65-3b6a557f3597}</Project>
       <Name>Prediktor.UA.Client</Name>
     </ProjectReference>
-	<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+	<PackageReference Include="GitVersion.MsBuild" Version="6.0.2">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua">
-      <Version>1.5.374.54</Version>
+      <Version>1.5.374.78</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/azure-pipeline-opcuaclient.yml
+++ b/azure-pipeline-opcuaclient.yml
@@ -57,6 +57,12 @@ stages:
           arguments: '--configuration $(buildConfiguration)'
         displayName: 'dotnet build $(buildConfiguration)'
 
+      - script: echo current version is $(Version.GitVersion.NugetVersionV2)
+        displayName: 'Print NugetVersionV2 - 2'
+  
+      - script: echo current version is $(Version.GitVersion.NugetVersionV2)
+        displayName: 'Print NugetVersionV2 - 2' 
+
       - task: DotNetCoreCLI@2
         displayName: 'Create NuGet Package - Release Version'
         inputs:

--- a/azure-pipeline-opcuaclient.yml
+++ b/azure-pipeline-opcuaclient.yml
@@ -57,12 +57,6 @@ stages:
           arguments: '--configuration $(buildConfiguration)'
         displayName: 'dotnet build $(buildConfiguration)'
 
-      - script: echo current version is $(Version.GitVersion.NugetVersionV2)
-        displayName: 'Print NugetVersionV2 - 2'
-  
-      - script: echo current version is $(Version.GitVersion.NugetVersionV2)
-        displayName: 'Print NugetVersionV2 - 2' 
-
       - task: DotNetCoreCLI@2
         displayName: 'Create NuGet Package - Release Version'
         inputs:
@@ -73,7 +67,7 @@ stages:
           nobuild: true
           includesymbols: true
           versioningScheme: 'byEnvVar'
-          versionEnvVar: 'Version.GitVersion.NugetVersionV2'
+          versionEnvVar: 'GitVersion.MajorMinorPatch'
 
       - publish: '$(Build.ArtifactStagingDirectory)/packages'
         artifact: 'packages'


### PR DESCRIPTION
Updated Nuget OPCFoundation.NetStandard.Opc.Ua To  V 1.5.374.78 (was V 1.5.374.54) Updated Nuget GitVersion.MsBuild to V 6.0.2 (was V 5.12.0)

Also, Bound up files in repo to solution file, So its viewable in VS.