### PR TITLE
Update Nuget OPCFoundation.NetStandard.Opc.Ua.

### DIFF
--- a/Prediktor.UA.Client/Prediktor.UA.Client.csproj
+++ b/Prediktor.UA.Client/Prediktor.UA.Client.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.78" />
+		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.118" />
 		<PackageReference Include="Prediktor.Log" Version="1.0.8" />
 		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated OPCFoundation.NetStandard.Opc.Ua to version 1.5.374.118 (was version 1.5.374.78)