### PR TITLE
Updatet .gitignore to ignore all net-versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@
 /Prediktor.UA.Console/bin
 /Prediktor.UA.Console/obj
 /CertGenCore/obj
-/CertGenCore/bin/Debug/net5.0
-/CertGenCore/bin/Debug/net6.0
+/CertGenCore/bin/Debug/net*.*
 /Prediktor.UA.Console/Properties/launchSettings.json

--- a/CertGenCore/CertGenCore.csproj
+++ b/CertGenCore/CertGenCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">

--- a/Prediktor.UA.Client/Prediktor.UA.Client.csproj
+++ b/Prediktor.UA.Client/Prediktor.UA.Client.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.118" />
+		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.374.126" />
 		<PackageReference Include="Prediktor.Log" Version="1.0.8" />
 		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Prediktor.UA.Client/Readme.md
+++ b/Prediktor.UA.Client/Readme.md
@@ -4,7 +4,7 @@
 Purpose
 -------
 
-The purpose of this assembly is to make connecting to an OPC UA klient easier than what it is when using the OPC UA Foundations SDK directly. 
+The purpose of this assembly is to make connecting to an OPC UA client easier than what it is when using the OPC UA Foundations SDK directly. 
 This is done by creating a SessionFactory that handles the creation of the UA session. 
 Commonly used methods will be placed in SessionExtensions class as extension methods for the Session.
 

--- a/Prediktor.UA.Console/Prediktor.UA.Console.csproj
+++ b/Prediktor.UA.Console/Prediktor.UA.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net8.0</TargetFramework>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -51,7 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua">
-      <Version>1.5.374.78</Version>
+      <Version>1.5.374.126</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Prediktor.UA.Console/Program.cs
+++ b/Prediktor.UA.Console/Program.cs
@@ -1,14 +1,10 @@
 ﻿using Opc.Ua;
-using Opc.Ua.Configuration;
 using Prediktor.UA.Client;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading.Tasks;
-using System.Security.Cryptography;
 namespace Prediktor.UA.Console
 {
 	class Program
@@ -354,8 +350,6 @@ namespace Prediktor.UA.Console
 
         private static void ReadHistoryProcessed(string server, Opc.Ua.NodeId[] nodeIds)
         {
-            HistoryReadResultCollection results;
-            DiagnosticInfoCollection diag;
             var fact = new ApplicationConfigurationFactory();
             var appConfig = fact.LoadFromFile("uaconfig.xml", true);
             var sessionFactory = new SessionFactory(cert => true);
@@ -391,8 +385,6 @@ namespace Prediktor.UA.Console
 
         private static void ReadHistoryRaw(string server, Opc.Ua.NodeId[] nodeIds)
         {
-            HistoryReadResultCollection results;
-            DiagnosticInfoCollection diag;
             var fact = new ApplicationConfigurationFactory();
             var appConfig = fact.LoadFromFile("uaconfig.xml", true);
             var sessionFactory = new SessionFactory(cert => true);
@@ -427,8 +419,6 @@ namespace Prediktor.UA.Console
 
         private static void ReadHistoryProcessedSecure(string server, Opc.Ua.NodeId[] nodeIds)
         {
-            HistoryReadResultCollection results;
-            DiagnosticInfoCollection diag;
             var fact = new ApplicationConfigurationFactory();
             var appConfig = fact.LoadFromFile("uaconfig.xml", true);
             var sessionFactory = new SessionFactory(cert => true);
@@ -450,7 +440,7 @@ namespace Prediktor.UA.Console
                 }
                 catch (Exception e)
                 {
-                    System.Console.WriteLine("historyData: ");
+                    System.Console.WriteLine("historyData: Error - {0}", e);
                 }
 
                 //         var hrdc = new HistoryReadValueIdCollection(new[] { new HistoryReadValueId() { NodeId = nodeId } });

--- a/azure-pipeline-opcuaclient.yml
+++ b/azure-pipeline-opcuaclient.yml
@@ -28,7 +28,7 @@ stages:
         displayName: 'Set up to use correct dotnet version'
         inputs:
           packageType: 'sdk'
-          version: '6.x'
+          version: '8.x'
       
       - task: NuGetCommand@2
         displayName: 'Restore nuget solution'


### PR DESCRIPTION
Updated OPCFoundation nuGet package references to version 1.5.374.126, as used in APIS_Foundation master branch Updated console apps CertGenCore and Prediktor.UA.Console to .net 8 Updated pipeline to use .net 8